### PR TITLE
Use local images across site

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <meta property="og:description" content="Durable, elegant epoxy floors. Metallic, flake & quartz systems. Free quotes in Tampa Bay." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://goldenepoxy.com/" />
-  <meta property="og:image" content="https://via.placeholder.com/1200x630?text=Cover" />
+  <meta property="og:image" content="images/main.jpg" />
 
   <!-- Tailwind CSS (CDN) -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -51,7 +51,7 @@
     "@context": "https://schema.org",
     "@type": "HomeAndConstructionBusiness",
     "name": "Golden Epoxy",
-    "image": "https://via.placeholder.com/1200x630?text=Cover",
+    "image": "images/main.jpg",
     "url": "https://goldenepoxy.com/",
     "telephone": "+1-813-580-0323",
     "priceRange": "$$",
@@ -127,7 +127,7 @@
         </div>
       </div>
       <div class="relative rounded-2xl overflow-hidden border border-white/10 shadow-2xl shine">
-        <img src="https://via.placeholder.com/800x600?text=Hero+Floor" alt="Metallic gold epoxy floor" class="w-full h-80 object-cover" />
+        <img src="images/main.jpg" alt="Example epoxy floor" class="w-full h-80 object-cover" />
       </div>
     </div>
   </section>
@@ -152,7 +152,7 @@
       <div class="mt-10 grid md:grid-cols-2 lg:grid-cols-3 gap-6">
         <!-- Card -->
         <article class="glass rounded-2xl overflow-hidden">
-          <img src="https://via.placeholder.com/400x300?text=Residential" alt="Residential epoxy floor" class="w-full h-40 object-cover" />
+          <img src="images/1.jpg" alt="Residential epoxy floor" class="w-full h-40 object-cover" />
           <div class="p-6">
             <h3 class="text-xl font-semibold">Residential Floors</h3>
             <p class="text-white/80 mt-2">Transform your garage, basement, or living space. Metallic, flake, and solid systems in bespoke colorways.</p>
@@ -160,7 +160,7 @@
         </article>
         <!-- Card -->
         <article class="glass rounded-2xl overflow-hidden">
-          <img src="https://via.placeholder.com/400x300?text=Commercial" alt="Commercial epoxy floor" class="w-full h-40 object-cover" />
+          <img src="images/2.jpg" alt="Commercial epoxy floor" class="w-full h-40 object-cover" />
           <div class="p-6">
             <h3 class="text-xl font-semibold">Commercial Floors</h3>
             <p class="text-white/80 mt-2">High-performance solutions for retail, offices, salons, gyms, and showrooms. Built for heavy foot traffic.</p>
@@ -168,7 +168,7 @@
         </article>
         <!-- Card -->
         <article class="glass rounded-2xl overflow-hidden">
-          <img src="https://via.placeholder.com/400x300?text=Industrial" alt="Industrial epoxy floor" class="w-full h-40 object-cover" />
+          <img src="images/3.jpg" alt="Industrial epoxy floor" class="w-full h-40 object-cover" />
           <div class="p-6">
             <h3 class="text-xl font-semibold">Industrial Coatings</h3>
             <p class="text-white/80 mt-2">Warehouses, production lines, and chemical-resistant systems that meet strict performance needs.</p>
@@ -176,7 +176,7 @@
         </article>
         <!-- Card -->
         <article class="glass rounded-2xl overflow-hidden">
-          <img src="https://via.placeholder.com/400x300?text=Decorative" alt="Metallic epoxy" class="w-full h-40 object-cover" />
+          <img src="images/4.jpg" alt="Decorative metallic epoxy" class="w-full h-40 object-cover" />
           <div class="p-6">
             <h3 class="text-xl font-semibold">Decorative Finishes</h3>
             <p class="text-white/80 mt-2">Metallic swirls, flake blends, quartz, and custom logos to turn floors into a feature.</p>
@@ -184,7 +184,7 @@
         </article>
         <!-- Card -->
         <article class="glass rounded-2xl overflow-hidden">
-          <img src="https://via.placeholder.com/400x300?text=Repair" alt="Concrete repair" class="w-full h-40 object-cover" />
+          <img src="images/5.jpg" alt="Concrete repair" class="w-full h-40 object-cover" />
           <div class="p-6">
             <h3 class="text-xl font-semibold">Floor Repairs</h3>
             <p class="text-white/80 mt-2">Crack repair, moisture mitigation, leveling, and surface prep for flawless adhesion.</p>
@@ -192,7 +192,7 @@
         </article>
         <!-- Card -->
         <article class="glass rounded-2xl overflow-hidden">
-          <img src="https://via.placeholder.com/400x300?text=Protective" alt="Protective coatings" class="w-full h-40 object-cover" />
+          <img src="images/6.jpg" alt="Protective coatings" class="w-full h-40 object-cover" />
           <div class="p-6">
             <h3 class="text-xl font-semibold">Protective Coatings</h3>
             <p class="text-white/80 mt-2">Anti-slip additives, UV stability, antimicrobial topcoats, and heavy-duty wear protection.</p>
@@ -240,8 +240,8 @@
           <p class="text-white/80 mt-3">Drag the handle to compare before and after. Our metallic and flake systems level, seal, and elevate concrete—fast.</p>
         </div>
         <div class="relative w-full aspect-[16/10] rounded-2xl overflow-hidden border border-white/10" id="compare">
-          <img src="https://via.placeholder.com/800x500?text=Before" alt="Before" class="absolute inset-0 w-full h-full object-cover" />
-          <img src="https://via.placeholder.com/800x500?text=After" alt="After" class="absolute inset-0 w-1/2 h-full object-cover clip" style="clip-path:inset(0 50% 0 0)" id="afterImg" />
+          <img src="images/7.jpg" alt="Floor before coating" class="absolute inset-0 w-full h-full object-cover" />
+          <img src="images/8.jpg" alt="Floor after coating" class="absolute inset-0 w-1/2 h-full object-cover clip" style="clip-path:inset(0 50% 0 0)" id="afterImg" />
           <input type="range" id="slider" min="0" max="100" value="50" aria-label="Before/after slider" class="absolute bottom-4 left-1/2 -translate-x-1/2 w-2/3">
         </div>
       </div>
@@ -262,12 +262,12 @@
       </div>
       <div class="mt-8 columns-1 sm:columns-2 lg:columns-3 gap-4 [column-fill:_balance]">
         <!-- Repeatable item -->
-        <figure class="mb-4 break-inside-avoid filter-item metallic"><img src="https://via.placeholder.com/400x300?text=Epoxy" alt="Metallic epoxy floor" class="w-full rounded-xl" /><figcaption class="sr-only">Metallic epoxy</figcaption></figure>
-        <figure class="mb-4 break-inside-avoid filter-item flake"><img src="https://via.placeholder.com/400x300?text=Epoxy" alt="Flake system" class="w-full rounded-xl" /></figure>
-        <figure class="mb-4 break-inside-avoid filter-item quartz"><img src="https://via.placeholder.com/400x300?text=Epoxy" alt="Quartz system" class="w-full rounded-xl" /></figure>
-        <figure class="mb-4 break-inside-avoid filter-item metallic"><img src="https://via.placeholder.com/400x300?text=Epoxy" alt="Metallic epoxy" class="w-full rounded-xl" /></figure>
-        <figure class="mb-4 break-inside-avoid filter-item flake"><img src="https://via.placeholder.com/400x300?text=Epoxy" alt="Flake system" class="w-full rounded-xl" /></figure>
-        <figure class="mb-4 break-inside-avoid filter-item quartz"><img src="https://via.placeholder.com/400x300?text=Epoxy" alt="Quartz system" class="w-full rounded-xl" /></figure>
+        <figure class="mb-4 break-inside-avoid filter-item metallic"><img src="images/1.jpg" alt="Metallic epoxy floor" class="w-full rounded-xl" /><figcaption class="sr-only">Metallic epoxy</figcaption></figure>
+        <figure class="mb-4 break-inside-avoid filter-item flake"><img src="images/2.jpg" alt="Flake system" class="w-full rounded-xl" /></figure>
+        <figure class="mb-4 break-inside-avoid filter-item quartz"><img src="images/3.jpg" alt="Quartz system" class="w-full rounded-xl" /></figure>
+        <figure class="mb-4 break-inside-avoid filter-item metallic"><img src="images/9.jpg" alt="Metallic epoxy finish" class="w-full rounded-xl" /></figure>
+        <figure class="mb-4 break-inside-avoid filter-item flake"><img src="images/10.jpg" alt="Flake system floor" class="w-full rounded-xl" /></figure>
+        <figure class="mb-4 break-inside-avoid filter-item quartz"><img src="images/11.jpg" alt="Quartz system floor" class="w-full rounded-xl" /></figure>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Reference bundled images instead of placeholders for meta tags and hero section
- Swap service cards, before/after slider, and gallery to use local photo assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68996761571083298aba511dcf82f0b6