### PR TITLE
fix: stretch nav logo to full height

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,10 @@
   <!-- Navbar -->
   <header class="sticky top-0 z-50 bg-coal-900/80 glass">
     <nav class="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
-      <a href="#" class="flex items-center gap-2 group">
-        <img src="images/logo.png" alt="Golden Epoxy logo" class="h-8 w-auto" />
+      <a href="#" class="flex items-center h-full gap-2 group">
+        <img src="images/logo.png"
+             alt="Golden Epoxy logo"
+             class="h-full w-auto object-contain" />
         <span class="font-semibold tracking-wide">Golden <span class="text-gold-400">Epoxy</span></span>
       </a>
       <ul class="hidden md:flex items-center gap-6 text-sm">


### PR DESCRIPTION
## Summary
- stretch navbar logo to span full nav height and preserve proportions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998fced6448329abafa9a180084d54