### PR TITLE
feat: hang logo below navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       <a href="#" class="flex items-center h-full gap-2 group">
         <img src="images/logo.png"
              alt="Golden Epoxy logo"
-             class="h-full w-auto object-contain" />
+             class="h-full w-auto object-contain transform translate-y-1/2" />
         <span class="font-semibold tracking-wide">Golden <span class="text-gold-400">Epoxy</span></span>
       </a>
       <ul class="hidden md:flex items-center gap-6 text-sm">


### PR DESCRIPTION
## Summary
- shift main logo downward so it hangs below the navbar and its center aligns with the bottom edge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68999455c2e48329bf078c64edf64fd1