### PR TITLE
Align navbar bottom with logo midline

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,12 +76,12 @@
   </div>
 
   <!-- Navbar -->
-  <header class="sticky top-0 z-50 bg-coal-900/80 glass">
+  <header class="sticky top-0 z-50 bg-coal-900/80 glass -mb-8">
     <nav class="max-w-7xl mx-auto px-4 h-24 flex items-center justify-between">
       <a href="#" class="flex items-center h-full gap-2 group">
         <img src="images/logo.png"
              alt="Golden Epoxy logo"
-             class="h-32 -mb-4 w-auto object-contain drop-shadow-lg self-start" />
+             class="h-32 w-auto object-contain drop-shadow-lg self-start" />
         <span class="font-semibold tracking-wide">Golden <span class="text-gold-400">Epoxy</span></span>
       </a>
       <ul class="hidden md:flex items-center gap-6 text-sm">


### PR DESCRIPTION
## Summary
- raise navbar by adding a negative bottom margin so it meets the logo's midpoint
- remove extra bottom margin from logo for balanced overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68999e4ccd588329821815f2d3d23a81