### PR TITLE
Remove all shadow filters from navbar logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
       <a href="#" class="flex items-center h-full gap-2 group">
         <img src="images/logo.png"
              alt="Golden Epoxy logo"
-             class="h-32 w-auto object-contain drop-shadow-lg self-start" />
+             class="h-32 w-auto object-contain self-start shadow-none drop-shadow-none filter-none" />
         <span class="font-semibold tracking-wide">Golden <span class="text-gold-400">Epoxy</span></span>
       </a>
       <ul class="hidden md:flex items-center gap-6 text-sm">


### PR DESCRIPTION
## Summary
- remove remaining shadow-related utilities from the navbar logo image
- explicitly disable Tailwind drop-shadow and box-shadow utilities so the logo renders flat

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68defbf0f24083298b506118f4c271da